### PR TITLE
Correct string given for method name search

### DIFF
--- a/src/Akkatecture/Sagas/AggregateSaga/AggregateSaga.cs
+++ b/src/Akkatecture/Sagas/AggregateSaga/AggregateSaga.cs
@@ -197,7 +197,7 @@ namespace Akkatecture.Sagas.AggregateSaga
                 .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(mi =>
                 {
-                    if (mi.Name != "Handle")
+                    if (mi.Name != "HandleAsync")
                         return false;
 
                     var parameters = mi.GetParameters();


### PR DESCRIPTION
In the InitAsyncReceives method, the hard-coded string used to search for saga-initialization methods should be "HandleAsync".