### PR TITLE
Move common properties to ICommittedEvent base interface

### DIFF
--- a/src/Akkatecture/Aggregates/CommittedEvent.cs
+++ b/src/Akkatecture/Aggregates/CommittedEvent.cs
@@ -27,6 +27,7 @@
 
 using System;
 using Akkatecture.Core;
+using Akkatecture.Extensions;
 
 namespace Akkatecture.Aggregates
 {
@@ -37,8 +38,8 @@ namespace Akkatecture.Aggregates
     {
         public TIdentity AggregateIdentity { get; }
         public TAggregateEvent AggregateEvent { get; }
-        public Metadata Metadata { get; }
         public long AggregateSequenceNumber { get; }
+	    public Metadata Metadata { get; }
         public DateTimeOffset Timestamp { get; }
 
         public CommittedEvent(
@@ -51,23 +52,28 @@ namespace Akkatecture.Aggregates
             if (aggregateEvent == null) throw new ArgumentNullException(nameof(aggregateEvent));
             if (metadata == null) throw new ArgumentNullException(nameof(metadata));
             if (timestamp == default(DateTimeOffset)) throw new ArgumentNullException(nameof(timestamp));
-            if (aggregateEvent == null) throw new ArgumentNullException(nameof(aggregateEvent));
             if (aggregateIdentity == null || string.IsNullOrEmpty(aggregateIdentity.Value)) throw new ArgumentNullException(nameof(aggregateIdentity));
-            
-            
-            AggregateIdentity = aggregateIdentity;
-            AggregateSequenceNumber = aggregateSequenceNumber;
-            AggregateIdentity = aggregateIdentity;
+
             AggregateEvent = aggregateEvent;
             Metadata = metadata;
             Timestamp = timestamp;
+            AggregateIdentity = aggregateIdentity;
+            AggregateSequenceNumber = aggregateSequenceNumber;
         }
-        
+
+        public IIdentity GetIdentity()
+        {
+            return AggregateIdentity;
+        }
+
         public IAggregateEvent GetAggregateEvent()
         {
             return AggregateEvent;
         }
 
-        
+        public override string ToString()
+        {
+            return $"{AggregateType.PrettyPrint()} v{AggregateSequenceNumber}/{EventType.PrettyPrint()}:{AggregateIdentity}";
+        }
     }
 }

--- a/src/Akkatecture/Aggregates/ICommittedEvent.cs
+++ b/src/Akkatecture/Aggregates/ICommittedEvent.cs
@@ -32,8 +32,17 @@ namespace Akkatecture.Aggregates
 {
     public interface ICommittedEvent
     {
+	    Type AggregateType { get; }
+	    Type IdentityType { get; }
+	    Type EventType { get; }
+	    long AggregateSequenceNumber { get; }
+	    Metadata Metadata { get; }
+	    DateTimeOffset Timestamp { get; }
 
+	    IIdentity GetIdentity();
+	    IAggregateEvent GetAggregateEvent();
     }
+
     public interface ICommittedEvent<TAggregate, out TIdentity> : ICommittedEvent
         where TAggregate : IAggregateRoot<TIdentity>
         where TIdentity : IIdentity
@@ -47,8 +56,5 @@ namespace Akkatecture.Aggregates
         where TAggregateEvent : IAggregateEvent<TAggregate, TIdentity>
     {
         TAggregateEvent AggregateEvent { get; }
-        Metadata Metadata { get; }
-        long AggregateSequenceNumber { get; }
-        DateTimeOffset Timestamp { get; }
     }
 }


### PR DESCRIPTION
Moved properties common to all CommittedEvents into the ICommittedEvent base interface. Adjusted CommittedEvent class to be more like DomainEvent class.