### PR TITLE
IExecute for command handlers interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- IExecute interface as an alternative way to add command handlers to the aggregate.
 
 ## [0.4.6] - 2019-07-27
 

--- a/examples/simple/Akkatecture.Examples.Domain/Model/UserAccount/UserAccountAggregate.cs
+++ b/examples/simple/Akkatecture.Examples.Domain/Model/UserAccount/UserAccountAggregate.cs
@@ -27,13 +27,13 @@ using Akkatecture.Examples.Domain.Model.UserAccount.Events;
 
 namespace Akkatecture.Examples.Domain.Model.UserAccount
 {
-    public class UserAccountAggregate : AggregateRoot<UserAccountAggregate,UserAccountId,UserAccountState>
+    public class UserAccountAggregate : AggregateRoot<UserAccountAggregate,UserAccountId,UserAccountState>,
+        IExecute<CreateUserAccountCommand>,
+        IExecute<UserAccountChangeNameCommand>
     {
         public UserAccountAggregate(UserAccountId id)
             : base(id)
         {
-            Command<CreateUserAccountCommand>(Execute);
-            Command<UserAccountChangeNameCommand>(Execute);
         }
         
         public bool Execute(CreateUserAccountCommand command)

--- a/src/Akkatecture/Aggregates/IExecute.cs
+++ b/src/Akkatecture/Aggregates/IExecute.cs
@@ -1,0 +1,38 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 - 2019 Lutando Ngqakaza
+// https://github.com/Lutando/Akkatecture 
+// 
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Akkatecture.Commands;
+
+namespace Akkatecture.Aggregates
+{
+    public interface IExecute
+    {
+        
+    }
+    
+    public interface IExecute<in TCommand> : IExecute
+        where TCommand : ICommand
+    {
+        bool Execute(TCommand command);
+    }
+}

--- a/test/Akkatecture.TestHelpers/Aggregates/TestAggregate.cs
+++ b/test/Akkatecture.TestHelpers/Aggregates/TestAggregate.cs
@@ -39,35 +39,32 @@ using Akkatecture.TestHelpers.Aggregates.Snapshots;
 namespace Akkatecture.TestHelpers.Aggregates
 {
     [AggregateName("Test")]
-    public sealed class TestAggregate : AggregateRoot<TestAggregate, TestAggregateId, TestAggregateState>
+    public sealed class TestAggregate : AggregateRoot<TestAggregate, TestAggregateId, TestAggregateState>, 
+        IExecute<CreateTestCommand>,
+        IExecute<CreateAndAddTwoTestsCommand>,
+        IExecute<AddTestCommand>,
+        IExecute<AddFourTestsCommand>,
+        IExecute<GiveTestCommand>,
+        IExecute<ReceiveTestCommand>,
+        IExecute<TestDistinctCommand>,
+        IExecute<PoisonTestAggregateCommand>,
+        IExecute<PublishTestStateCommand>,
+        IExecute<TestDomainErrorCommand>,
+        IExecute<TestFailedExecutionResultCommand>,
+        IExecute<TestSuccessExecutionResultCommand>
     {
         public int TestErrors { get; private set; }
         public TestAggregate(TestAggregateId aggregateId)
             : base(aggregateId)
         {
             TestErrors = 0;
-            //Aggregate Commands
-            Command<CreateTestCommand>(Execute);
-            Command<CreateAndAddTwoTestsCommand>(Execute);
-            Command<AddTestCommand>(Execute);
-            Command<AddFourTestsCommand>(Execute);
-            Command<GiveTestCommand>(Execute);
-            Command<ReceiveTestCommand>(Execute);
-            Command<TestDistinctCommand>(Execute);
-
-            //Aggregate Test Probe Commands
-            Command<PoisonTestAggregateCommand>(Execute);
-            Command<PublishTestStateCommand>(Execute);
-            Command<TestDomainErrorCommand>(Execute);
-            Command<TestFailedExecutionResultCommand>(Execute);
-            Command<TestSuccessExecutionResultCommand>(Execute);
 
             Command<SaveSnapshotSuccess>(SnapshotStatus);
 
             SetSnapshotStrategy(new SnapshotEveryFewVersionsStrategy(10));
         }
 
-        private bool Execute(CreateTestCommand command)
+        public bool Execute(CreateTestCommand command)
         {
             if (IsNew)
             {
@@ -85,7 +82,7 @@ namespace Akkatecture.TestHelpers.Aggregates
         }
         
 
-        private bool Execute(CreateAndAddTwoTestsCommand command)
+        public bool Execute(CreateAndAddTwoTestsCommand command)
         {
             if (IsNew)
             {
@@ -105,7 +102,7 @@ namespace Akkatecture.TestHelpers.Aggregates
             return true;
         }
 
-        private bool Execute(AddTestCommand command)
+        public bool Execute(AddTestCommand command)
         {
             if (!IsNew)
             {
@@ -123,7 +120,7 @@ namespace Akkatecture.TestHelpers.Aggregates
             return true;
         }
 
-        private bool Execute(AddFourTestsCommand command)
+        public bool Execute(AddFourTestsCommand command)
         {
             if (!IsNew)
             {
@@ -145,7 +142,7 @@ namespace Akkatecture.TestHelpers.Aggregates
             return true;
         }
 
-        private bool Execute(GiveTestCommand command)
+        public bool Execute(GiveTestCommand command)
         {
             if (!IsNew)
             {
@@ -166,7 +163,7 @@ namespace Akkatecture.TestHelpers.Aggregates
             return true;
         }
 
-        private bool Execute(ReceiveTestCommand command)
+        public bool Execute(ReceiveTestCommand command)
         {
             if (!IsNew)
             {
@@ -182,23 +179,23 @@ namespace Akkatecture.TestHelpers.Aggregates
 
             return true;
         }
-        private bool Execute(TestFailedExecutionResultCommand command)
+        public bool Execute(TestFailedExecutionResultCommand command)
         {
             Sender.Tell(ExecutionResult.Failed(), Self);
             return true;
         }
         
-        private bool Execute(TestSuccessExecutionResultCommand command)
+        public bool Execute(TestSuccessExecutionResultCommand command)
         {
             Sender.Tell(ExecutionResult.Success(), Self);
             return true;
         }
-        private bool Execute(TestDistinctCommand command)
+        public bool Execute(TestDistinctCommand command)
         {
             return true;
         }
 
-        private bool Execute(PoisonTestAggregateCommand command)
+        public bool Execute(PoisonTestAggregateCommand command)
         {
             if (!IsNew)
             {
@@ -214,7 +211,7 @@ namespace Akkatecture.TestHelpers.Aggregates
             return true;
         }
 
-        private bool Execute(PublishTestStateCommand command)
+        public bool Execute(PublishTestStateCommand command)
         {
             Signal(new TestStateSignalEvent(State,LastSequenceNr,Version));
 
@@ -222,7 +219,7 @@ namespace Akkatecture.TestHelpers.Aggregates
         }
 
 
-        private bool Execute(TestDomainErrorCommand command)
+        public bool Execute(TestDomainErrorCommand command)
         {
             TestErrors++;
             Throw(new TestedErrorEvent(TestErrors));


### PR DESCRIPTION
This allows for the use of IExecute interface to signify command handlers for aggregate roots