### PR TITLE
fix GetAll postman collection url in Web example

### DIFF
--- a/examples/web/PostmanCollection/Akkatecture.Api.Example.postman_collection.json
+++ b/examples/web/PostmanCollection/Akkatecture.Api.Example.postman_collection.json
@@ -61,7 +61,7 @@
 						"header": [],
 						"body": {},
 						"url": {
-							"raw": "{{ApiUrl}}api/resources",
+							"raw": "{{ApiUrl}}/api/resources",
 							"host": [
 								"{{ApiUrl}}api"
 							],


### PR DESCRIPTION
fix missing slash in GetAll postman collection url in Web example

Changed 
{{ApiUrl}}api/resources
to
{{ApiUrl}}/api/resources